### PR TITLE
Se arregla ruta de Scroll to top que faltaba

### DIFF
--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -18,7 +18,7 @@ export default function ScrollToTop() {
       }}
       className="scroll-top"
     >
-      <img src="./img/scroll-to-top.svg" alt="scroll-button" />
+      <img src="/img/scroll-to-top.svg" alt="scroll-button" />
     </button>
   );
 }


### PR DESCRIPTION
Debido al tema que se rompen imágenes en rutas anidadas, se cambió el src de una que había olvidado arreglar, que era el scroll to top